### PR TITLE
Make a default Github org

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -73,8 +73,8 @@ docs_type:
         How would you like to document your project?
         You can start with just a README and change your answer to add a sphinx project later.
     choices:
-        - README
         - sphinx
+        - README
 
 _subdirectory: "template"
 

--- a/copier.yml
+++ b/copier.yml
@@ -25,6 +25,7 @@ github_org:
         Set to your GitHub username to make a personal repo, or DiamondLightSource
         if you have permissions to make it in the DiamondLightSource organisation.
     when: "{{ git_platform == 'github.com' }}"
+    default: DiamondLightSource
 
 repo_name:
     type: str

--- a/copier.yml
+++ b/copier.yml
@@ -73,8 +73,8 @@ docs_type:
         How would you like to document your project?
         You can start with just a README and change your answer to add a sphinx project later.
     choices:
-        - sphinx
         - README
+        - sphinx
 
 _subdirectory: "template"
 


### PR DESCRIPTION
Set the default Github org to DiamondLightSource, this is an opinioned template and the 80% use case will be DiamondLightSource, so may as well streamline it without precluding other orgs.