### PR TITLE
Fix dist job where dist_name != package_name

### DIFF
--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/code.yml
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/code.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Test module --version works using the installed wheel
         # If more than one module in src/ replace with module name to test
-        run: python -m $(ls src | head -1) --version
+        run: python -m $(ls --hide='*.egg-info' src | head -1) --version
 
   container:
     needs: [lint, dist, test]


### PR DESCRIPTION
If the dist_name precedes package name alphabetically then it would pick the .egg-info
file instead of the src directory. Exclude this