### PR TITLE
Add example publishing

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -6,6 +6,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Avoid git conflicts when tag and branch pushed at same time
+        if: github.ref_type == 'tag'
+        run: sleep 60
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/_example.yml
+++ b/.github/workflows/_example.yml
@@ -1,0 +1,34 @@
+on:
+  workflow_call:
+    secrets:
+      EXAMPLE_DEPLOY_KEY:
+        required: true
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need this to get version number from last tag
+          fetch-depth: 0
+
+      - name: Regenerate example
+        run: |
+          pipx run copier copy --data-file example-answers.yml --trust --vcs-ref=HEAD . example
+
+      - name: Rewrite copier answers
+        run: |
+          sed -i 's|_src_path: .|_src_path: gh:DiamondLightSource/python-copier-template|' example/.copier-answers.yml
+
+      - name: Publish example
+        # We pin to the SHA, not the tag, for security reasons.
+        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        with:
+          deploy_key: ${{ secrets.EXAMPLE_DEPLOY_KEY }}
+          publish_dir: example
+          external_repository: DiamondLightSource/python-copier-template-example
+          publish_branch: main
+          enable_jekyll: true  # don't put a .nojekyll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
     permissions:
       contents: write
 
+  example:
+    if: github.ref_name == 'main'
+    uses: ./.github/workflows/_example.yml
+    secrets:
+      EXAMPLE_DEPLOY_KEY: ${{ secrets.EXAMPLE_DEPLOY_KEY }}
+
   release:
     if: github.ref_type == 'tag'
     needs: docs

--- a/example-answers.yml
+++ b/example-answers.yml
@@ -1,0 +1,11 @@
+author_email: tom.cobb@diamond.ac.uk
+author_name: Tom Cobb
+component_owner: group:default/sscc
+description: An expanded python-copier-template with all the options
+distribution_name: dls-python-copier-template-example
+docker: true
+docs_type: sphinx
+git_platform: github.com
+github_org: DiamondLightSource
+package_name: python_copier_template_example
+repo_name: python-copier-template-example

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -11,22 +11,10 @@ from prompt_toolkit.validation import ValidationError
 TOP = Path(__file__).absolute().parent.parent
 
 
-def copy_project(
-    project_path: Path,
-    author_email="tom.cobb@diamond.ac.uk",
-    author_name="Tom Cobb",
-    component_owner="group:default/sscc",
-    description="An expanded python-copier-template with all the options",
-    distribution_name="dls-python-copier-template-example",
-    docker=True,
-    docs_type="sphinx",
-    git_platform="github.com",
-    github_org="DiamondLightSource",
-    package_name="python_copier_template_example",
-    repo_name="python-copier-template-example",
-):
-    answers = locals()
-    answers.pop("project_path")
+def copy_project(project_path: Path, **kwargs):
+    with open(TOP / "example-answers.yml") as f:
+        answers = yaml.safe_load(f)
+    answers.update(kwargs)
     run_copy(
         src_path=str(TOP),
         dst_path=project_path,


### PR DESCRIPTION
This keeps python-copier-template-example up to date whenever python-copier-template has a push to main