### PR TITLE
Fix ruff config deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ commands =
 [tool.ruff]
 src = ["src", "tests"]
 line-length = 88
-select = [
+lint.select = [
     "E", # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
     "F", # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f
     "W", # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -98,11 +98,10 @@ commands =
     docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html
 """
 
-
 [tool.ruff]
 src = ["src", "tests"]
 line-length = 88
-select = [
+lint.select = [
     "C4",   # flake8-comprehensions - https://beta.ruff.rs/docs/rules/#flake8-comprehensions-c4
     "E",    # pycodestyle errors - https://beta.ruff.rs/docs/rules/#error-e
     "F",    # pyflakes rules - https://beta.ruff.rs/docs/rules/#pyflakes-f


### PR DESCRIPTION
The warning was

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`: - 'select' -> 'lint.select'
```