### PR TITLE
Make template .gitignore a file

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,1 +1,70 @@
-../.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+**/_version.py
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+cov.xml
+.pytest_cache/
+.mypy_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# likely venv names
+.venv*
+venv*
+
+# further build artifacts
+lockfiles/
+
+# ruff cache
+.ruff_cache/

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -95,3 +95,10 @@ def test_example_repo_updates(tmp_path: Path):
         f"{generated_path} {example_path}"
     )
     assert not output, output
+
+
+def test_gitignore_same():
+    with open(TOP / ".gitignore") as top_gi, open(
+        TOP / "template" / ".gitignore"
+    ) as template_gi:
+        assert top_gi.read() == template_gi.read()


### PR DESCRIPTION
Otherwise we get:
    warning: unable to access 'template/.gitignore': Too many levels of symbolic links

Add a test to make sure the root and template .gitignores are the same