### PR TITLE
Rename tox envs by task not technology

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -51,7 +51,7 @@ jobs:
           pip-install: ".[dev]"
 
       - name: Run tests
-        run: tox -e pytest
+        run: tox -e tests
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/docs/how-to/coverage.md
+++ b/docs/how-to/coverage.md
@@ -1,7 +1,7 @@
 
 # How to check code coverage
 
-Code coverage is reported to the command line and to a `cov.xml` file by the command `tox -e pytest`. The file is uploaded to the Codecov service in CI.
+Code coverage is reported to the command line and to a `cov.xml` file by the command `tox -e tests`. The file is uploaded to the Codecov service in CI.
 
 ## Adding a Codecov Token
 

--- a/docs/how-to/run-tests.md
+++ b/docs/how-to/run-tests.md
@@ -11,7 +11,7 @@ $ pytest
 When you have some fully working tests then you can run it with coverage:
 
 ```
-$ tox -e pytest-cov
+$ tox -e tests
 ```
 
 It will also report coverage to the commandline and to `cov.xml`.

--- a/docs/how-to/static-analysis.md
+++ b/docs/how-to/static-analysis.md
@@ -3,5 +3,5 @@
 Static type analysis is done with [pyright](https://microsoft.github.io/pyright/). It checks type definition in source files without running them, and highlights potential issues where types do not match. You can run it with:
 
 ```
-$ tox -e pyright
+$ tox -e type-checking
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ legacy_tox_ini = """
 [tox]
 skipsdist=True
 
-[testenv:{pre-commit,pytest,docs}]
+[testenv:{pre-commit,tests,docs}]
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
@@ -47,7 +47,7 @@ allowlist_externals =
     sphinx-autobuild
 commands =
     pre-commit: pre-commit run --all-files --show-diff-on-failure {posargs}
-    pytest: pytest {posargs}
+    tests: pytest {posargs}
     docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html
 """
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -79,7 +79,7 @@ legacy_tox_ini = """
 [tox]
 skipsdist=True
 
-[testenv:{pre-commit,pyright,pytest{% if sphinx %},docs{% endif %}}]
+[testenv:{pre-commit,type-checking,tests{% if sphinx %},docs{% endif %}}]
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
@@ -90,9 +90,9 @@ allowlist_externals =
 {% if sphinx %}    sphinx-build
     sphinx-autobuild
 {% endif %}commands =
-    pytest: pytest --cov={{ package_name }} --cov-report term --cov-report xml:cov.xml {posargs}
-    pyright: pyright src tests {posargs}
     pre-commit: pre-commit run --all-files {posargs}
+    type-checking: pyright src tests {posargs}
+    tests: pytest --cov={{ package_name }} --cov-report term --cov-report xml:cov.xml {posargs}
 {% if sphinx %}    docs: sphinx-{posargs:build -EW --keep-going} -T docs build/html
 {% endif %}"""
 

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -13,7 +13,7 @@ jobs:
     if: needs.check.outputs.branch-pr == ''
     uses: ./.github/workflows/_tox.yml
     with:
-      tox: pre-commit,pyright
+      tox: pre-commit,type-checking
 {% raw %}
   test:
     needs: check


### PR DESCRIPTION
Allows us to switch between pyright and mypy without changing CI and the commands people type