### PR TITLE
add cd into tasks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -105,4 +105,5 @@ sphinx:
 _subdirectory: "template"
 
 _tasks:
-    - "git init --initial-branch=main"
+    - cd {{ _copier_conf.dst_path }}
+    - git init --initial-branch=main


### PR DESCRIPTION
I've seen two issues with creating a new folder from scratch:

1. you must supply a full path for the folder in the copier command line - otherwise it appears in / 
2. cwd will not be in the new folder so the tasks will fail

This PR is a fix for 2.

I also have in my own templates:
```
    # Add the remote if it doesn't exist
    - if ! git remote | grep origin; then git remote add origin {{repo_url}}; fi
```

That way you can just do a push after creation. If it is gitlab at DLS then you can do a push without first creating the repo (maybe thats a little too good?).

I did not add the above into this PR because I note that your repo_url internal value looks to be hardcoded for github, but that could be fixed. 

Here is what I do https://github.com/epics-containers/ec-services-template/blob/c08341d3cd83d407e1b5b178f1e8208794a8c411/copier.yml#L142-L150)

This explicitly exposes the repo URI so the user could override if wanted.