### PR TITLE
Change fetch location to absolute url

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -95,7 +95,7 @@ spec:
       name: Fetch Base
       action: fetch:copier
       input:
-        url: gh:DiamondLightSource/python-copier-template
+        url: https://github.com/DiamondLightSource/python-copier-template
         values:
           destination: ${{ parameters.repoUrl | parseRepoUrl }}
           # These are answers for the copier template

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,8 +1,8 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: python_copier_template_url
-  title: Python Copier Template URL
+  name: python_copier_template
+  title: Python Copier Template
   description: Create a project based on this template using Copier
   tags:
     - recommended

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,8 +1,8 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: python_copier_template
-  title: Python Copier Template
+  name: python_copier_template_url
+  title: Python Copier Template URL
   description: Create a project based on this template using Copier
   tags:
     - recommended
@@ -95,7 +95,7 @@ spec:
       name: Fetch Base
       action: fetch:copier
       input:
-        url: .
+        url: gh:DiamondLightSource/python-copier-template
         values:
           destination: ${{ parameters.repoUrl | parseRepoUrl }}
           # These are answers for the copier template


### PR DESCRIPTION
No longer copies the whole repo into a temp directory for copier to run on.
Copier will run directly using the latest tagged repo as it's source
Gives the _commit and correct _src_path which hence allows for updates to the project in the future

Fixes #118 