### PR TITLE
Add pytest configuration for break on exception

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,10 @@
                 "debug-test"
             ],
             "console": "integratedTerminal",
+            "env": {
+                // Enable break on exception when debugging tests (see: tests/conftest.py)
+                "PYTEST_RAISE": "1",
+            },
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Debug Unit Test",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "justMyCode": false,
             "program": "${file}",

--- a/template/tests/conftest.py
+++ b/template/tests/conftest.py
@@ -1,0 +1,1 @@
+../../tests/conftest.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+# Prevent pytest from catching exceptions when debugging in vscode so that break on
+# exception works correctly (see: https://github.com/pytest-dev/pytest/issues/7409)
+if os.getenv("PYTEST_RAISE", "0") == "1":
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call):
+        raise call.excinfo.value
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo):
+        raise excinfo.value


### PR DESCRIPTION
Pytest nicely catches raised exceptions during tests and reports them at the end. This is very useful except when debugging tests in vscode because it prevents the debugger from pausing when there is an exception and displaying the call stack.

This adds hooks for pytest to re-raise the caught exceptions when an environment variable is set, and then sets that environment variable in the `Debug Unit Test` launch configuration.

This is currently used in [pvi](https://github.com/epics-containers/pvi).