### PR TITLE
Replace references to skeleton with copier template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/DiamondLightSource/python3-pip-skeleton-cli/main/docs/images/dls-logo.svg"
+<img src="https://raw.githubusercontent.com/DiamondLightSource/python-copier-template/main/docs/images/dls-logo.svg"
      style="background: none" width="120px" height="120px" align="right">
 
 [![CI](https://github.com/DiamondLightSource/python-copier-template/actions/workflows/ci.yml/badge.svg)](https://github.com/DiamondLightSource/python-copier-template/actions/workflows/ci.yml)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,10 +119,10 @@ if not switcher_exists:
 # Theme options for pydata_sphinx_theme
 # We don't check switcher because there are 3 possible states for a repo:
 # 1. New project, docs are not published so there is no switcher
-# 2. Existing project with latest skeleton, switcher exists and works
-# 3. Existing project with old skeleton that makes broken switcher,
+# 2. Existing project with latest copier template, switcher exists and works
+# 3. Existing project with old copier template that makes broken switcher,
 #    switcher exists but is broken
-# Point 3 makes checking switcher difficult, because the updated skeleton
+# Point 3 makes checking switcher difficult, because the updated copier template
 # will fix the switcher at the end of the docs workflow, but never gets a chance
 # to complete as the docs build warns and fails.
 html_theme_options = {
@@ -131,13 +131,6 @@ html_theme_options = {
     },
     "use_edit_page_button": True,
     "github_url": f"https://github.com/{github_user}/{github_repo}",
-    "icon_links": [
-        {
-            "name": "PyPI",
-            "url": "https://pypi.org/project/python3-pip-skeleton",
-            "icon": "fas fa-cube",
-        }
-    ],
     "switcher": {
         "json_url": switcher_json,
         "version_match": version,

--- a/template/{% if sphinx %}docs{% endif %}/conf.py.jinja
+++ b/template/{% if sphinx %}docs{% endif %}/conf.py.jinja
@@ -135,10 +135,10 @@ if not switcher_exists:
 # Theme options for pydata_sphinx_theme
 # We don't check switcher because there are 3 possible states for a repo:
 # 1. New project, docs are not published so there is no switcher
-# 2. Existing project with latest skeleton, switcher exists and works
-# 3. Existing project with old skeleton that makes broken switcher,
+# 2. Existing project with latest copier template, switcher exists and works
+# 3. Existing project with old copier template that makes broken switcher,
 #    switcher exists but is broken
-# Point 3 makes checking switcher difficult, because the updated skeleton
+# Point 3 makes checking switcher difficult, because the updated copier template
 # will fix the switcher at the end of the docs workflow, but never gets a chance
 # to complete as the docs build warns and fails.
 html_theme_options = {


### PR DESCRIPTION
Remove PyPI button from docs as this project is not published to PyPI.

Fixes #137.