### PR TITLE
Add `contents:read` permission to container workflow

### DIFF
--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -39,6 +39,7 @@ jobs:
     if: needs.check.outputs.branch-pr == ''
     uses: ./.github/workflows/_container.yml
     permissions:
+      contents: read
       packages: write
 {% endif %}{% if sphinx %}
   docs:


### PR DESCRIPTION
This is required to allow the workflow job to checkout the code, currently we're getting around this because our repos are public