### PR TITLE
Add Issue and PR Templates

### DIFF
--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/bug_report.md
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+about: The template to use for reporting bugs and usability issues
+title: " "
+labels: 'bug'
+assignees: ''
+
+---
+
+Describe the bug, including A clear and concise description of the expected behavior, the actual behavior and the context in which you encountered it (ideally include details of your environment).
+
+## Steps To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+
+## Acceptance Criteria
+- Specific criteria that will be used to judge if the issue is fixed

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/bug_report.md
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Describe the bug, including A clear and concise description of the expected behavior, the actual behavior and the context in which you encountered it (ideally include details of your environment).
+Describe the bug, including a clear and concise description of the expected behavior, the actual behavior and the context in which you encountered it (ideally include details of your environment).
 
 ## Steps To Reproduce
 Steps to reproduce the behavior:

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/issue.md
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,13 @@
+---
+name: Issue
+about: The standard template to use for feature requests, design discussions and tasks
+title: " "
+labels: ''
+assignees: ''
+
+---
+
+A brief description of the issue, including specific stakeholders and the business case where appropriate
+
+## Acceptance Criteria
+- Specific criteria that will be used to judge if the issue is fixed

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,8 @@
+Fixes #ISSUE
+
+### Instructions to reviewer on how to test:
+1. Do thing x
+2. Confirm thing y happens
+
+### Checks for reviewer
+- [ ] Would the PR title make sense to a user on a set of release notes


### PR DESCRIPTION
Fixes #159 

Add Issue and PR templates based on
https://github.com/DiamondLightSource/dodal, but genercised slightly. Stick with dodal's simplistic ethos rather than have many prescriptive headings and sections, instead prompting the user to put useful information in the most appropriate place for them