### PR TITLE
Enable SLF001 for src

### DIFF
--- a/docs/explanations/decisions/0018-forbid-private-member-access-in-prod.md
+++ b/docs/explanations/decisions/0018-forbid-private-member-access-in-prod.md
@@ -1,0 +1,20 @@
+# 18. Forbid Private Member Access in Production Code
+
+Date: 2024-07-02
+
+## Status
+
+Accepted
+
+## Context
+
+Most programming languages forbid access to private member variables at compile time to guarantee encapsulation. Python only does this by convention. Ruff now provides a rule (SLF001) that forbids it.
+See https://github.com/DiamondLightSource/python-copier-template/issues/154 for further discussion.
+
+## Decision
+
+We will enable SLF001 for the `src` directory but not the `tests` directory, as we want to keep production code clean without raising the barrier to entry for writing tests.
+
+## Consequences
+
+Any private member access in `src` will cause CI to fail, the ultimate override of `noqa` remains available.

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -102,11 +102,18 @@ allowlist_externals =
 src = ["src", "tests"]
 line-length = 88
 lint.select = [
-    "B",  # flake8-bugbear - https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
-    "C4", # flake8-comprehensions - https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
-    "E",  # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
-    "F",  # pyflakes rules - https://docs.astral.sh/ruff/rules/#pyflakes-f
-    "W",  # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#warning-w
-    "I",  # isort - https://docs.astral.sh/ruff/rules/#isort-i
-    "UP", # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "B",   # flake8-bugbear - https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "C4",  # flake8-comprehensions - https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "E",   # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
+    "F",   # pyflakes rules - https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "W",   # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#warning-w
+    "I",   # isort - https://docs.astral.sh/ruff/rules/#isort-i
+    "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "SLF", # self - https://docs.astral.sh/ruff/settings/#lintflake8-self
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# By default, private member access is allowed in tests
+# See https://github.com/DiamondLightSource/python-copier-template/issues/154
+# Remove this line to forbid private member access in tests
+"tests/**/*" = ["SLF001"]


### PR DESCRIPTION
Fixes #154 

- Enable SLF001, forbidding private member access in src directory.
- Per discussion in #154, ignore private member access violations in tests directory
- Add test proving that ruff flags the violations