### PR TITLE
Explicitly put pyright in standard mode

### DIFF
--- a/docs/how-to/strict-mode.md
+++ b/docs/how-to/strict-mode.md
@@ -4,11 +4,11 @@ For projects using pyright you can enable strict mode for stricter than normal t
 
 ## Configuration
 
-Add the `strict` line to `pyproject.toml` as follows:
+Change the `typeCheckingMode` line to `"strict"` in `pyproject.toml` as follows:
 
 ```toml
 [tool.pyright]
-strict = ["src", "tests"]
+typeCheckingMode = "strict"
 reportMissingImports = false # Ignore missing stubs in imported modules
 ```
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -52,6 +52,7 @@ name = "{{ author_name }}"
 version_file = "src/{{ package_name }}/_version.py"
 {% if type_checker=="pyright" %}
 [tool.pyright]
+typeCheckingMode = "standard"
 reportMissingImports = false # Ignore missing stubs in imported modules
 {% endif %}{% if type_checker=="mypy" %}
 [tool.mypy]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -157,7 +157,8 @@ def test_works_in_pyright_strict_mode(tmp_path: Path):
 
     # Enable strict mode
     run_pipe(
-        f'sed -i \'/\\[tool.pyright\\]/a\\strict = ["src", "tests"]\' {pyproject_toml}'
+        'sed -i \'s|typeCheckingMode = "standard"|typeCheckingMode = "strict"|\''
+        f" {pyproject_toml}"
     )
 
     # Ensure pyright is still happy


### PR DESCRIPTION
It is implicitly in standard mode, but vscode does not know this, so only reports basic mode errors.

This change makes vscode show the same errors that pyright does