### PR TITLE
Uncap copier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [
-    "copier < 9.4",  # https://github.com/copier-org/copier/issues/1819
+    "copier",
     "myst-parser",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",


### PR DESCRIPTION
As https://github.com/copier-org/copier/issues/1819 is released as 9.4.1

This reverts commit c8b2891a5aff627a63ef14a9491050891e195f8a.