### PR TITLE
set attestations to false in pypi release ci

### DIFF
--- a/.github/workflows/_pypi.yml
+++ b/.github/workflows/_pypi.yml
@@ -15,3 +15,5 @@ jobs:
 
       - name: Publish to PyPI using trusted publishing
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false


### PR DESCRIPTION
This has already been shown to fix release in pandablocks-ioc and ophyd-async.