### PR TITLE
switch from common-utils feature to bash-config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,11 @@
         }
     },
     "features": {
-        // Some default things like git config
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "upgradePackages": false
-        }
+        // add in eternal history and other bash features
+        "ghcr.io/diamondlightsource/devcontainer-features/bash-config:1.0.0": {}
     },
+    // Create the config folder for the bash-config feature
+    "initializeCommand": "mkdir -p ${localEnv:HOME}/.config/bash-config",
     "runArgs": [
         // Allow the container to access the host X11 display and EPICS CA
         "--net=host",


### PR DESCRIPTION
Use Richard Cunningham's lightweight bash-config feature instead of common utils.

The rebuild container overhead for this is approx 10 secs as opposed to 40-60 secs according to https://github.com/DiamondLightSource/python-copier-template/issues/208#issuecomment-2456876823

See below for details on what this feature does
https://github.com/DiamondLightSource/devcontainer-features/blob/main/.devcontainer/features/bash-config/README.md
