### PR TITLE
fix: Remove docs references to test outputs

### DIFF
--- a/.github/workflows/_docs.yml
+++ b/.github/workflows/_docs.yml
@@ -1,9 +1,5 @@
 on:
   workflow_call:
-    inputs:
-      publish:
-        type: boolean
-        description: If true, publishes docs to gh-pages
 
 
 jobs:
@@ -49,7 +45,7 @@ jobs:
         run: python .github/pages/make_switcher.py --add $DOCS_VERSION ${{ github.repository }} .github/pages/switcher.json
 
       - name: Publish Docs to gh-pages
-        if: inputs.publish && (github.ref_type == 'tag' || github.ref_name == 'main')
+        if: github.ref_type == 'tag' || github.ref_name == 'main'
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
 
   docs:
     uses: ./.github/workflows/_docs.yml
-    with:
-      publish: ${{needs.test.result == 'success'}}
     permissions:
       contents: write
 

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -37,13 +37,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-{% endraw %}{% endif %}{% if sphinx %}{% raw %}
+{% endraw %}{% endif %}{% if sphinx %}
   docs:
     uses: ./.github/workflows/_docs.yml
-    with:
-      publish: ${{ needs.test.result == 'success' }}
 
-{% endraw %}{% endif %}
+{% endif %}
   dist:
     uses: ./.github/workflows/_dist.yml
   {% if pypi %}


### PR DESCRIPTION
The docs workflow currently requires the output of the tests workflow, which is not listed in `docs.needs`.

This PR removes all references to test outputs from the docs workflow.