### PR TITLE
fix: Handle pinned sha versions of Python in the install_requirements action

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -15,6 +15,7 @@ runs:
       run: |
         PYTHON_VERSION="${{ inputs.python-version }}"
         if [ $PYTHON_VERSION == "dev" ]; then
+          # python version from Dockerfile, removing potential pinned sha
           PYTHON_VERSION=$(sed -Ene "s/ARG PYTHON_VERSION=([0-9\.]+).*/\1/p" Dockerfile)
         fi
         echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"

--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -15,7 +15,7 @@ runs:
       run: |
         PYTHON_VERSION="${{ inputs.python-version }}"
         if [ $PYTHON_VERSION == "dev" ]; then
-          PYTHON_VERSION=$(sed -n "s/ARG PYTHON_VERSION=//p" Dockerfile)
+          PYTHON_VERSION=$(sed -Ene "s/ARG PYTHON_VERSION=([0-9\.]+).*/\1/p" Dockerfile)
         fi
         echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"
       shell: bash


### PR DESCRIPTION
When PYTHON_VERSION is pinned to a specific sha (as done by Renovate best-practices), install_requirements fails as the container tag is not a valid version of python when including the sha. This trims the trailing part of the tag to just the [0-9\.]+ part which should be the valid python version.