### PR TITLE
fix: Deduplicate jobs from generated workflows

### DIFF
--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - '*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Re-fixes the issue in #253 which made modifications to only one of the ci.yaml files and therefore only to this repository's workflows not the workflows of generated repos.