### PR TITLE
feat: Enable pep8-naming ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,14 @@ lint.select = [
     "C4", # flake8-comprehensions - https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "E",  # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
     "F",  # pyflakes rules - https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "N",  # pep8-naming - https://docs.astral.sh/ruff/rules/#pep8-naming-n
     "W",  # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#warning-w
     "I",  # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP", # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore variable names inside the template because ruff doesn't 
+# work well with jinja templating. Any violations of N rules inside
+# the template are caught by the tests.
+"template/**/*" = ["N"]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -109,6 +109,7 @@ lint.select = [
     "C4",  # flake8-comprehensions - https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
     "E",   # pycodestyle errors - https://docs.astral.sh/ruff/rules/#error-e
     "F",   # pyflakes rules - https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "N",   # pep8-naming - https://docs.astral.sh/ruff/rules/#pep8-naming-n
     "W",   # pycodestyle warnings - https://docs.astral.sh/ruff/rules/#warning-w
     "I",   # isort - https://docs.astral.sh/ruff/rules/#isort-i
     "UP",  # pyupgrade - https://docs.astral.sh/ruff/rules/#pyupgrade-up

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -223,6 +223,21 @@ print(obj._bar)
         run("ruff check")
 
 
+def test_pep8_naming(tmp_path: Path):
+    code = """
+myVariable = "foo"
+"""
+
+    copy_project(tmp_path)
+    run = make_venv(tmp_path)
+
+    src_file = tmp_path / "src" / "python_copier_template_example" / "bad_example.py"
+    with src_file.open("w") as stream:
+        stream.write(code)
+    with pytest.raises(AssertionError, match=r"N816 .*"):
+        run("ruff check")
+
+
 def test_pyright_works_in_standard_typing_mode(tmp_path: Path):
     copy_project(tmp_path, type_checker="pyright", strict_typing=False)
     pyproject_toml = tmp_path / "pyproject.toml"


### PR DESCRIPTION
Fixes #282

Enable pep8-naming ruff rules, enforcing that projects follow convetional pep8 naming styles. See https://peps.python.org/pep-0008