### PR TITLE
ci(gitleaks): add pre-commit hook, config with sealed-secrets allowlist, and tests

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,7 @@
+# This allow-list is limited to YAML/YML files to cut down SealedSecrets false positives.
+# All gitleaks default rules still apply everywhere (useDefault = true).
+# To broaden this allow-list to all files, comment out the 'paths' line below.
+
 [extend]
 useDefault = true
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+
+# Pattern-only allowlist for long Ag… tokens in YAML 
+[[rules.allowlists]]
+condition = "AND"
+regexes = [
+  # Boundary-safe Ag… token without lookarounds (RE2-safe)
+  '''(?:^|[^A-Za-z0-9+/=])(Ag[A-Za-z0-9+/]{500,}={0,2})(?:[^A-Za-z0-9+/=]|$)'''
+]
+# Limit to YAML only for now. Comment this out if you want it to apply everywhere.
+paths = ['''(?i).*\.ya?ml$''']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
         language: system
         entry: uv sync
         files: ^(uv\.lock|pyproject\.toml)$
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks

--- a/template/.gitleaks.toml
+++ b/template/.gitleaks.toml
@@ -1,0 +1,1 @@
+../.gitleaks.toml

--- a/tests/test_gitleaks_precommit.py
+++ b/tests/test_gitleaks_precommit.py
@@ -32,16 +32,38 @@ def test_gitleaks_stable_patterns_fail(tmp_path: Path, fname: str, content: str)
 
 
 # --- Sealed-secrets: YAML/YML allowlisted; non-YAML should be flagged ---
-def _fake_sealed_secret_blob(n: int = 800) -> str:
-    body = ("Qw9+/" * ((n // 4) + 1))[:n]
-    return "Ag" + body + "=="
-
-
-def test_gitleaks_yaml_allowlist_for_sealed_secrets(tmp_path: Path):
+def _fake_sealed_secret_blob(n: int = 800, seed: str = "sealed-secrets-test") -> str:
     """
-    Keep .gitleaks.toml as-is (realistic behavior).
-    - In .yaml/.yml: blob under spec.encryptedData -> allowlisted -> hook PASS
-    - In non-YAML: same blob in code -> not allowlisted -> hook FAIL
+    Generate a deterministic, base64-looking ciphertext that resembles a SealedSecret.
+    - Always starts with 'Ag'
+    - Uses a realistic base64 alphabet mix (via sha256-derived bytes)
+    - Adds '=' padding only if required by base64 length
+    - Deterministic for stable tests (change `seed` to vary appearance)
+    """
+    import base64
+    import hashlib
+
+    # Build a deterministic byte stream from the seed, not random
+    chunk = hashlib.sha256(seed.encode("utf-8")).digest()  # 32 bytes
+    raw = (chunk * ((n // len(chunk)) + 4))[: n + 64]  # extra slack, then trim
+
+    # Base64-encode -> realistic distribution of A–Z a–z 0–9 + /
+    b64 = base64.b64encode(raw).decode("ascii")
+
+    # Compose with 'Ag' prefix and keep length near n
+    body = b64.replace("=", "")  # remove padding from the body
+    s = "Ag" + body[:n]  # ensure 'Ag' at start
+
+    # Fix padding so total length is a multiple of 4 (valid base64-looking)
+    rem = len(s) % 4
+    if rem:
+        s += "=" * (4 - rem)
+    return s
+
+
+def test_gitleaks_yaml_allowlist_for_sealed_secrets_yaml(tmp_path: Path):
+    """
+    Case 1: .yaml (allowlisted => PASS)
     """
     blob = _fake_sealed_secret_blob()
 
@@ -56,7 +78,6 @@ spec:
     token: "{blob}"
 """
 
-    # Case 1: .yaml (allowlisted => PASS)
     proj_yaml = tmp_path / "proj_yaml"
     proj_yaml.mkdir()
     copy_project(proj_yaml)
@@ -65,7 +86,24 @@ spec:
     run_yaml("git add -A")
     run_yaml("./venv/bin/tox -e pre-commit")
 
-    # Case 2: .yml (allowlisted => PASS)
+
+def test_gitleaks_yaml_allowlist_for_sealed_secrets_yml(tmp_path: Path):
+    """
+    Case 2: .yml (allowlisted => PASS)
+    """
+    blob = _fake_sealed_secret_blob()
+
+    sealed_yaml = f"""\
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: demo
+  namespace: default
+spec:
+  encryptedData:
+    token: "{blob}"
+"""
+
     proj_yml = tmp_path / "proj_yml"
     proj_yml.mkdir()
     copy_project(proj_yml)
@@ -74,7 +112,13 @@ spec:
     run_yml("git add -A")
     run_yml("./venv/bin/tox -e pre-commit")
 
-    # Case 3: non-YAML (should be flagged => FAIL)
+
+def test_leaky_code_fails_gitleaks(tmp_path: Path):
+    """
+    Case 3: non-YAML (should be flagged => FAIL)
+    """
+    blob = _fake_sealed_secret_blob()
+
     proj_code = tmp_path / "proj_code"
     proj_code.mkdir()
     copy_project(proj_code)

--- a/tests/test_gitleaks_precommit.py
+++ b/tests/test_gitleaks_precommit.py
@@ -28,7 +28,7 @@ def test_gitleaks_stable_patterns_fail(tmp_path: Path, fname: str, content: str)
     run("git add -A")  # pre-commit's gitleaks scans the staged index
 
     with pytest.raises(AssertionError, match=r"(?i)(leak|gitleaks|secret)"):
-        run("./venv/bin/tox -e pre-commit")
+        run(".venv/bin/tox -e pre-commit")
 
 
 # --- Sealed-secrets: YAML/YML allowlisted; non-YAML should be flagged ---
@@ -84,7 +84,7 @@ spec:
     run_yaml = make_venv(proj_yaml)
     (proj_yaml / "secret.yaml").write_text(sealed_yaml)
     run_yaml("git add -A")
-    run_yaml("./venv/bin/tox -e pre-commit")
+    run_yaml(".venv/bin/tox -e pre-commit")
 
 
 def test_gitleaks_yaml_allowlist_for_sealed_secrets_yml(tmp_path: Path):
@@ -110,7 +110,7 @@ spec:
     run_yml = make_venv(proj_yml)
     (proj_yml / "secret.yml").write_text(sealed_yaml)
     run_yml("git add -A")
-    run_yml("./venv/bin/tox -e pre-commit")
+    run_yml(".venv/bin/tox -e pre-commit")
 
 
 def test_leaky_code_fails_gitleaks(tmp_path: Path):
@@ -126,4 +126,4 @@ def test_leaky_code_fails_gitleaks(tmp_path: Path):
     (proj_code / "leaky.py").write_text(f'api_key = "{blob}"\n')
     run_code("git add -A")
     with pytest.raises(AssertionError, match=r"(?i)(leak|gitleaks|secret)"):
-        run_code("./venv/bin/tox -e pre-commit")
+        run_code(".venv/bin/tox -e pre-commit")

--- a/tests/test_gitleaks_precommit.py
+++ b/tests/test_gitleaks_precommit.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import pytest
+
+from test_example import copy_project, make_venv
+
+# --- Stable patterns gitleaks flags out-of-the-box (should FAIL) ---
+STABLE_LEAK_CASES = [
+    ("github_token.txt", "ghp_1234567890abcdefghijklmnopqrstuvwx12AB"),
+    (
+        "slack_webhook.txt",
+        "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    ),
+    ("stripe_secret.txt", "sk_test_4eC39HqLyjWDarjtT1zdp7dcFAKE"),
+]
+
+
+@pytest.mark.parametrize("fname, content", STABLE_LEAK_CASES)
+def test_gitleaks_stable_patterns_fail(tmp_path: Path, fname: str, content: str):
+    """
+    Generate a project, add a known-leaky pattern, stage it,
+    and verify tox -e pre-commit (gitleaks) fails.
+    """
+    copy_project(tmp_path)
+    run = make_venv(tmp_path)
+
+    (tmp_path / fname).write_text(content)
+    run("git add -A")  # pre-commit's gitleaks scans the staged index
+
+    with pytest.raises(AssertionError, match=r"(?i)(leak|gitleaks|secret)"):
+        run("./venv/bin/tox -e pre-commit")
+
+
+# --- Sealed-secrets: YAML/YML allowlisted; non-YAML should be flagged ---
+def _fake_sealed_secret_blob(n: int = 800) -> str:
+    body = ("Qw9+/" * ((n // 4) + 1))[:n]
+    return "Ag" + body + "=="
+
+
+def test_gitleaks_yaml_allowlist_for_sealed_secrets(tmp_path: Path):
+    """
+    Keep .gitleaks.toml as-is (realistic behavior).
+    - In .yaml/.yml: blob under spec.encryptedData -> allowlisted -> hook PASS
+    - In non-YAML: same blob in code -> not allowlisted -> hook FAIL
+    """
+    blob = _fake_sealed_secret_blob()
+
+    sealed_yaml = f"""\
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: demo
+  namespace: default
+spec:
+  encryptedData:
+    token: "{blob}"
+"""
+
+    # Case 1: .yaml (allowlisted => PASS)
+    proj_yaml = tmp_path / "proj_yaml"
+    proj_yaml.mkdir()
+    copy_project(proj_yaml)
+    run_yaml = make_venv(proj_yaml)
+    (proj_yaml / "secret.yaml").write_text(sealed_yaml)
+    run_yaml("git add -A")
+    run_yaml("./venv/bin/tox -e pre-commit")
+
+    # Case 2: .yml (allowlisted => PASS)
+    proj_yml = tmp_path / "proj_yml"
+    proj_yml.mkdir()
+    copy_project(proj_yml)
+    run_yml = make_venv(proj_yml)
+    (proj_yml / "secret.yml").write_text(sealed_yaml)
+    run_yml("git add -A")
+    run_yml("./venv/bin/tox -e pre-commit")
+
+    # Case 3: non-YAML (should be flagged => FAIL)
+    proj_code = tmp_path / "proj_code"
+    proj_code.mkdir()
+    copy_project(proj_code)
+    run_code = make_venv(proj_code)
+    (proj_code / "leaky.py").write_text(f'api_key = "{blob}"\n')
+    run_code("git add -A")
+    with pytest.raises(AssertionError, match=r"(?i)(leak|gitleaks|secret)"):
+        run_code("./venv/bin/tox -e pre-commit")


### PR DESCRIPTION
## Summary

* Enable **gitleaks** as a pre-commit hook to help prevent committing secrets.
* Add an **allowlist** for sealed-secrets (long `Ag…` patterns), scoped to `*.yml` / `*.yaml`.
* To extend the allowlist all files repo-wide, **comment the entire** `paths` line in `.gitleaks.toml` file.

---

## How to test

I verified this change with:

```
pre-commit run --all-files
```

This should include output from **gitleaks**, scanning for potential hardcoded secrets.

For local testing, I used:

```
python3 -m venv .venv
source .venv/bin/activate
pip install pre-commit
pre-commit install --hook-type pre-commit
pre-commit run --all-files
```

Depending on your environment, testing may happen differently:

* **Devcontainer**: pre-commit hooks (including gitleaks) bootstrapped automatically
* **CI**: pre-commit hooks run as part of the lint stage (e.g., `tox -e pre-commit`)

---

## Manual spot checks

1. **Secret detection**

   * Try committing a file with a fake API key/private key → commit should be blocked by gitleaks.

2. **Allowlist works (YAML only)**

   * Place a sealed-secret-like long `Ag…` token in a `.yaml`/`.yml` file → should be allowlisted.
   * Place the same token in a non-YAML file → should be flagged.

> The allowlist is regex-based and may occasionally cause false positives or false negatives, but it provides better protection than having no scanning in place.

---

## Notes
* gitleaks may produce false positives (flagging non-secrets) or false negatives (missing real secrets)
* To extend the allowlist beyond YAML, **comment out the entire** `paths` line in `.gitleaks.toml`
*  For more information, including configuration options for customizing detection rules, refer to the official documentation:
    https://github.com/gitleaks/gitleaks
