### PR TITLE
fix: Enable subprocess coverage

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -71,6 +71,7 @@ filterwarnings = "error"
 testpaths = "docs src tests"
 
 [tool.coverage.run]
+patch = ["subprocess"]
 data_file = "/tmp/{{ package_name }}.coverage"
 
 [tool.coverage.paths]


### PR DESCRIPTION
The default CLI test in new projects runs `__main__.py` in a subprocess, until pytest-cov 7.0.0 subprocesses were automatically included in coverage but that has now changed and we must explicitly enable it in order to avoid sudden unexpected drops in code coverage.

See docs: https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html