### PR TITLE
chore: Use shared volume for devcontainer uv cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,9 +56,9 @@
         },
         // Keep a persistent cross container cache for uv
         {
-            "source": "${localEnv:HOME}/.cache/uv",
+            "source": "persistent-uv-cache",
             "target": "/root/.cache/uv",
-            "type": "bind"
+            "type": "volume"
         },
         // Use a volume mount for the uv venv so it is local to the container
         {


### PR DESCRIPTION
Instead of mounting the user's local cache. For the first use this will
be slower (if the user has previously used uv) but using a separate
volume means links within the cache referring to devcontainer locations
will not interfere with uv being run from outside the container.

Using a named volume means devcontainers for multiple projects can share
the same cache.
