### PR TITLE
chore: Use shared volume for pre-commit cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,9 +56,9 @@
         },
         // Keep a persistent cross container cache for uv
         {
-            "source": "${localEnv:HOME}/.cache/uv",
+            "source": "persistent-uv-cache",
             "target": "/root/.cache/uv",
-            "type": "bind"
+            "type": "volume"
         },
         // Use a volume mount for the uv venv so it is local to the container
         {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,6 +60,12 @@
             "target": "/root/.cache/uv",
             "type": "volume"
         },
+        // ...and for pre-commit
+        {
+            "source": "persistent-pre-commit-cache",
+            "target": "/root/.cache/pre-commit",
+            "type": "volume"
+        },
         // Use a volume mount for the uv venv so it is local to the container
         {
             "target": "/workspaces/${localWorkspaceFolderBasename}/.venv",


### PR DESCRIPTION
Once the uv cache has been set up, configuring the pre-commit hooks
takes the most significant amount of time building the container. Using
a shared volume for the pre-commit cache as well takes the devcontainer
re-build time from ~1m10s to ~10s.
