### PR TITLE
fix: Better handling of large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
-        args: ["--maxkb=1000"] # uv.lock is more than 500kB
+        exclude: ^uv.lock
       - id: check-yaml
       - id: check-merge-conflict
       - id: end-of-file-fixer


### PR DESCRIPTION
Whitelists the uv.lock file for the large files check, rather than allowing all files to increase in size.
This also allows for the case (e.g. blueapi) where the uv.lock file is >1000kB.