### PR TITLE
refactor: Reformat link table template in README

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,13 +10,13 @@
 This is where you should write a short paragraph that describes what your module does,
 how it does it, and why people should use it.
 
-What                           | Where
-:---:                          | :---:
-Source                         | <{{repo_url}}>
-{% if pypi   %}PyPI            | `pip install {{distribution_name}}`{% endif %}
-{% if docker %}Docker          | `docker run ghcr.io/{{github_org | lower}}/{{repo_name}}:latest`{% endif %}
-{% if sphinx %}Documentation   | <{{docs_url}}>{% endif %}
-Releases                       | <{{repo_url}}/releases>
+{#                      #}What            | Where
+{#                      #}:---:           | :---:
+{#                      #}Source          | <{{repo_url}}>
+{% if pypi              %}PyPI            | `pip install {{distribution_name}}`
+{% endif %}{% if docker %}Docker          | `docker run ghcr.io/{{github_org | lower}}/{{repo_name}}:latest`
+{% endif %}{% if sphinx %}Documentation   | <{{docs_url}}>
+{% endif                %}Releases        | <{{repo_url}}/releases>
 
 This is where you should put some images or code snippets that illustrate
 some relevant examples. If it is a library then you might put some

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,12 +10,13 @@
 This is where you should write a short paragraph that describes what your module does,
 how it does it, and why people should use it.
 
-{% if True              %}Source          | <{{repo_url}}>
-{% endif %}{% if True   %}:---:           | :---:
-{% endif %}{% if pypi   %}PyPI            | `pip install {{distribution_name}}`
-{% endif %}{% if docker %}Docker          | `docker run ghcr.io/{{github_org | lower}}/{{repo_name}}:latest`
-{% endif %}{% if sphinx %}Documentation   | <{{docs_url}}>
-{% endif                %}Releases        | <{{repo_url}}/releases>
+What                           | Where
+:---:                          | :---:
+Source                         | <{{repo_url}}>
+{% if pypi   %}PyPI            | `pip install {{distribution_name}}`{% endif %}
+{% if docker %}Docker          | `docker run ghcr.io/{{github_org | lower}}/{{repo_name}}:latest`{% endif %}
+{% if sphinx %}Documentation   | <{{docs_url}}>{% endif %}
+Releases                       | <{{repo_url}}/releases>
 
 This is where you should put some images or code snippets that illustrate
 some relevant examples. If it is a library then you might put some


### PR DESCRIPTION
Having the source and repo link as a 'normal' row makes it clearer what
is going on and stops 'Source' looking like a description of the other
link types.
