### PR TITLE
feat: Add lazygit to default install of devcontainer template

### DIFF
--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Test cli works in cached runtime image
         run: docker run --rm tag_for_testing --version
 
+      - name: Test lazygit cli works in container
+        run: lazygit --version
+
       - name: Create tags for publishing image
         id: meta
         uses: docker/metadata-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,16 @@ FROM ghcr.io/diamondlightsource/ubuntu-devcontainer:noble AS developer
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     graphviz \
     && apt-get dist-clean
+
+# Can replace with "apt install lazygit" when Ubuntu >= 25.10
+# Download and install latest lazygit binary
+RUN LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" \
+    | grep -Po '"tag_name": "v\K[^"]*') \
+    && echo "Installing lazygit version: $LAZYGIT_VERSION" \
+    && curl -Lo lazygit.tar.gz \
+    "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" \
+    && tar xf lazygit.tar.gz lazygit \
+    && install lazygit /usr/local/bin
+
+# Cleanup
+RUN rm lazygit.tar.gz lazygit

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -7,6 +7,20 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     graphviz \
     && apt-get dist-clean{% if docker %}
 
+# Can replace with "apt install lazygit" when Ubuntu >= 25.10
+# Download and install latest lazygit binary
+RUN LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" \
+    | grep -Po '"tag_name": "v\K[^"]*') \
+    && echo "Installing lazygit version: $LAZYGIT_VERSION" \
+    && curl -Lo lazygit.tar.gz \
+    "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" \
+    && tar xf lazygit.tar.gz lazygit \
+    && install lazygit /usr/local/bin
+
+# Cleanup
+RUN rm lazygit.tar.gz lazygit
+
+
 # The build stage installs the context into the venv
 FROM developer AS build
 


### PR DESCRIPTION
Can be simplified to an apt install once upgrading to at least a 25.10 base image