### PR TITLE
fix: Force uv to manage python itself

### DIFF
--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -21,7 +21,7 @@ ENV UV_PYTHON_INSTALL_DIR=/python
 
 # Sync the project without its dev dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable --no-dev
+    uv sync --locked --no-editable --no-dev --managed-python
 
 {% if docker_debug %}
 FROM build AS debug


### PR DESCRIPTION
By default uv will use a system installed version of python when available. We don't want this as later in the Dockerfile we require /python to exist which it wont if uv has used a system installed version. This will happen if the requested version of python is the same as the default version in the base image.
https://docs.astral.sh/uv/concepts/python-versions/#requiring-or-disabling-managed-python-versions