### PR TITLE
feat: Add support for python 3.14 to copier template

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -10,6 +10,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 description = "{{ description }}"
 dependencies = [] # Add project dependencies here, e.g. ["click", "numpy"]

--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:


### PR DESCRIPTION
Addresses #315 

Updates python-copier-template to add python 3.14 to the template.

As discussed in the issue, support for the existing 3.11 oldest python version is retained to increase the number of supported pythons to 4 versions.
