### PR TITLE
fix: copier should not be a dev dependency

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The template has tests for:
 However, this does not test whether processes like CI and docs work correctly. You can ensure that these are checked by:
 
 - Making your changes on a branch of <https://github.com/DiamondLightSource/python-copier-template>
-- Running `copier update --vcs-ref=<branch_name>` in the repo where you would like to demonstrate the behaviour
+- Running `uvx copier update --vcs-ref=<branch_name>` in the repo where you would like to demonstrate the behaviour
 - Linking to that demonstration repo in the PR
 
 ## Developer Information

--- a/docs/how-to/update-template.md
+++ b/docs/how-to/update-template.md
@@ -5,7 +5,7 @@
 To track changes to the upstream template, run
 
 ```
-copier update
+uvx copier update
 ```
 
 This will fetch the latest tagged release of the template, and apply any changes to your working copy. It will prompt for answers again, giving your previous answers as the defaults.
@@ -32,7 +32,7 @@ The following steps are recommended to update your project, especially for infre
 - fix issues found by the above
 - commit the changes
 - update the template
-    - `copier update`
+    - `uvx copier update`
 - fix any merge conflicts
 - validate that the project still works
     - `tox -p`

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -21,7 +21,6 @@ requires-python = ">=3.11"
 
 [dependency-groups]
 dev = [
-    "copier",
     {% if type_checker=="mypy" %}"mypy",
     {% endif %}{% if sphinx %}"myst-parser",
     {% endif %}"pre-commit",


### PR DESCRIPTION
## Summary

`copier` should not be installed as a dev dependency of *generated* projects — it should be invoked via `uvx copier` instead. This PR removes it from the template's dev dependency group and updates the docs to recommend `uvx copier update`.

- `template/pyproject.toml.jinja`: removed `"copier"` from the `dev` dependency-group list.
- `docs/how-to/update-template.md`: changed the two bare `copier update` invocations to `uvx copier update`.
- `.github/CONTRIBUTING.md`: changed `copier update --vcs-ref=<branch_name>` to `uvx copier update --vcs-ref=<branch_name>`.

## Deliberately left untouched

- Root `pyproject.toml` — this template repo's own test suite imports `copier` (`from copier import run_copy`), so it legitimately needs `copier` as a dev dependency here.
- `tests/test_example.py` — its bare `copier update` call runs in this repo's own dev environment, not inside a generated project.
- Tutorial docs (`docs/tutorials/adopt-existing.md`, `docs/tutorials/create-new.md`) and prose/comment mentions of "copier" — already correct or out of scope.

## Testing

- `uv run --locked tox -e pre-commit` — passed.
- `uv run --locked tox -e tests` — 5 pre-existing failures unrelated to this change (sandbox network proxy blocks a docs-build version-switcher request to `diamondlightsource.github.io`, and one test has a version-string mismatch from running off an untagged commit rather than a release tag). No failures caused by this change; `test_example_repo_updates`'s actual file-content diff was clean aside from that unrelated version string.

Closes #343


---
_Generated by [Claude Code](https://claude.ai/code/session_01VuHBQ1iEZogr1q7VBjA2iL)_