### PR TITLE
fix: disable Renovate Dockerfile base-image updates in downstream repos

### DIFF
--- a/template/renovate.json.jinja
+++ b/template/renovate.json.jinja
@@ -36,6 +36,17 @@
         "github-actions"
       ],
       "enabled": false
+    },
+    {
+      "description": "Disable Dockerfile base images that are managed by python-copier-template",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "matchDepNames": [
+        "ubuntu",
+        "ghcr.io/diamondlightsource/ubuntu-devcontainer"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Downstream repos generated from this template were receiving Renovate PRs (e.g. "Update ubuntu Docker tag") for Docker base images that are only ever meant to be bumped centrally, in `template/Dockerfile.jinja`. This PR adds a `packageRule` to `template/renovate.json.jinja` — the config shipped to downstream projects — that disables Renovate's `dockerfile` manager for the two template-managed base images (`ubuntu` and `ghcr.io/diamondlightsource/ubuntu-devcontainer`), mirroring the existing rules that already disable `pyenv` and template-managed GitHub Actions.

The rule is appended to the **end** of the `packageRules` array (not inserted before the existing github-actions rule), since `tests/test_example.py::test_renovate_actions_match_what_is_shipped` hard-indexes `packageRules[1]` as the github-actions rule.

## Originating request

From a maintainer comment on [bluesky/scanspec#211](https://github.com/bluesky/scanspec/issues/211): Renovate was opening Docker base-image bump PRs in downstream repos, but those base images are managed centrally by this template — the update should only ever happen here, not downstream.

## Deliberately left alone

- **Root `renovate.json`** (this template repo's own Renovate config) was **not** changed — this repo should keep receiving Docker base-image updates itself, since it's the one place those bumps are supposed to land.
- `template/Dockerfile.jinja`, the root `Dockerfile`, workflows, and `uv.lock` were not touched.

## Verification

Ran locally from the repo root, as CI does:
- `uv run --locked tox -e pre-commit` — passed.
- `uv run --locked tox -e tests` — `test_renovate_actions_match_what_is_shipped` passes for all 5 parametrized scenarios (no-docker, docker, docker+debug, pypi, sphinx docs). Two pre-existing, unrelated failures were confirmed to reproduce identically on unmodified `main` (a docs-build test blocked by network/proxy restrictions in this sandbox, and a template-version-hash mismatch in a generated doc link) — left untouched as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J29WGmqiaFAwfavJrqwon7)_