### PR TITLE
ci: run workflows on merge_group events

### DIFF
--- a/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
+++ b/template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja
@@ -7,6 +7,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
 
 jobs:
 


### PR DESCRIPTION
## What changed

Adds `merge_group:` to the `on:` trigger list in the generated CI workflow: `template/{% if git_platform=="github.com" %}.github{% endif %}/workflows/ci.yml.jinja`. A single-line addition, nothing else — the template repo's own `.github/workflows/ci.yml` (which tests the template itself) is untouched, out of scope for this change.

## Why

No merge queue is enabled by default on projects generated from this template, but if one were turned on, GitHub only runs a workflow against `gh-readonly-queue/*` refs when that workflow explicitly subscribes to the `merge_group` event. Neither `push` nor `pull_request` covers it, so a queued PR would sit there indefinitely waiting on checks that never start. This change makes generated projects' CI queue-ready ahead of time.

## What this PR is *not*

This PR does **not** enable a merge queue for any project. Turning one on is a repo-admin ruleset / branch-protection setting outside a workflow file's control — that decision stays with whoever administers each downstream repo. Until it's flipped on, this change is a safe no-op: `merge_group` events simply never fire.

## Confirmed safe under `merge_group`

- The tag-gated pypi/release jobs stay off — under `merge_group` the ref is `gh-readonly-queue/main/pr-N-<sha>`, which is `ref_type == 'branch'`, not `tag`.
- The `main`-gated docs-deploy job stays off for the same reason (`ref_name` under `merge_group` isn't `main`).

So no release or deploy can fire from a merge-queue run in any generated project.

## Test suite

Ran `uv run --locked tox -e tests` before pushing. 4 pre-existing failures remain (`docs`/Sphinx trying to fetch `switcher.json` from `diamondlightsource.github.io`), all caused by this sandbox's outbound network restrictions — reproducible on a clean checkout with no changes, unrelated to this PR. `pre-commit` and `type-checking` pass. No test snapshots or asserts on the generated CI workflow's content, so nothing needed updating for this change.

## Downstream repos

This is the durable upstream fix. `bluesky/bluesky` and `bluesky/ophyd-async` carry the identical `merge_group:` addition directly (both currently generated from this template) until they next re-run copier and pick it up from here:

- bluesky/bluesky#2055
- bluesky/ophyd-async#1411

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9bkocE5cCMw4LC72sJFHm)_